### PR TITLE
Add a GitHub Actions workflow using a shared-setup

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,31 @@
+---
+name: Build, Test & Lint
+on:
+  push:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        target: [android, ios]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nickcharlton/react-native-setup@main
+      - run: yarn build-${{ matrix.target }}
+
+  lint:
+    runs-on: macos-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nickcharlton/react-native-setup@main
+      - run: yarn lint
+
+  test:
+    runs-on: macos-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nickcharlton/react-native-setup@main
+      - run: yarn test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "build-android": "yarn react-native build-android --no-packager",
+    "build-ios": "yarn react-native build-ios --mode Debug"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
This configures a multi-step workflow to build, test and lint a React Native application. It depends on the shared setup repo, where it pulls in it's configuration.

https://github.com/nickcharlton/react-native-setup